### PR TITLE
Add Rate Limiter Service

### DIFF
--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/Constants.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/Constants.java
@@ -1,0 +1,28 @@
+package ru.mfilatov.prayingtimes.telegrambot;
+
+public class Constants {
+  public static final String HELP_MESSAGE =
+      """
+            **Help Menu**
+
+            Here are the available commands:
+            /start - Show the main menu
+            /help - Get help and instructions
+            /prayertimes - Get prayer times for your location
+
+            To get started, share your location and choose a calculation method.
+            Source code: https://github.com/map7000/timeskeeper""";
+
+  public static final String DEFAULT_MESSAGE =
+      """
+            Sorry, I didn't understand that command.
+            Use /help to see available commands.""";
+
+  public static final String MENU_MESSAGE =
+      """
+            Welcome to the Prayer Time Bot!
+            Use the commands below to interact with the bot:
+            /start - Show this menu
+            /help - Get help and instructions
+            /prayertimes - Get prayer times for your location""";
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
@@ -4,11 +4,10 @@
  */
 package ru.mfilatov.prayingtimes.telegrambot;
 
-import java.util.ArrayList;
-import java.util.List;
+import static ru.mfilatov.prayingtimes.telegrambot.Constants.*;
+
 import java.util.Objects;
 import java.util.regex.Pattern;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,14 +18,12 @@ import org.telegram.telegrambots.longpolling.starter.SpringLongPollingBot;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 import ru.mfilatov.prayingtimes.telegrambot.clients.TimeskeeperClient;
-import ru.mfilatov.prayingtimes.telegrambot.entities.Event;
+import ru.mfilatov.prayingtimes.telegrambot.counter.RateLimiterService;
 import ru.mfilatov.prayingtimes.telegrambot.entities.User;
-import ru.mfilatov.prayingtimes.telegrambot.repositories.EventRepository;
+import ru.mfilatov.prayingtimes.telegrambot.events.EventHandler;
 import ru.mfilatov.prayingtimes.telegrambot.repositories.UserRepository;
 
 @Slf4j
@@ -36,24 +33,24 @@ public class PrayingTimesAzanBot
 
   private final TelegramClient telegramClient;
   private final TimeskeeperClient client;
-  private final EventRepository events;
+  private final EventHandler events;
   private final UserRepository users;
+  private final RateLimiterService rateLimiter;
   private final String botToken;
 
   private static final Pattern ALPHANUMERIC_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s.,!?-]+$");
-  private static final int MAX_REQUESTS_PER_USER = 10; // Max requests per user per minute
-  private static final long RATE_LIMIT_TIME_WINDOW = 60_000; // 1 minute in milliseconds
-
-  // Simulated rate-limiting storage (in a real application, use a proper cache or database)
-  private final java.util.Map<Long, Integer> userRequestCounts = new java.util.HashMap<>();
-  private final java.util.Map<Long, Long> userLastRequestTimes = new java.util.HashMap<>();
 
   @Autowired
   public PrayingTimesAzanBot(
-      TimeskeeperClient client, EventRepository events, UserRepository users, @Value("${BOT_TOKEN}") String token) {
+      TimeskeeperClient client,
+      EventHandler events,
+      UserRepository users,
+      RateLimiterService rateLimiter,
+      @Value("${BOT_TOKEN}") String token) {
     this.client = client;
     this.events = events;
     this.users = users;
+    this.rateLimiter = rateLimiter;
     this.botToken = token;
 
     this.telegramClient = new OkHttpTelegramClient(getBotToken());
@@ -71,51 +68,33 @@ public class PrayingTimesAzanBot
 
   @Override
   public void consume(Update update) {
+    Double latitude;
+    Double longitude;
+
     Long chatId = update.getMessage().getChatId();
 
-    // Rate limiting check
-    if (isRateLimited(chatId)) {
+    if (rateLimiter.isRateLimited(chatId)) {
       sendMessage(chatId, "⚠️ Too many requests. Please try again later.");
       return;
     }
 
-    // Input validation
-    if (!isValidInput(update.getMessage().getText())) {
-      sendMessage(chatId, "⚠️ Invalid input. Please use only letters, numbers, and common symbols.");
-      return;
-    }
-
-    Double latitude;
-    Double longitude;
-
-    if (update.hasMessage()) {
+    if (update.hasMessage() && update.getMessage().hasText()) {
+      if (!isValidInput(update.getMessage().getText())) {
+        sendMessage(
+            chatId, "⚠️ Invalid input. Please use only letters, numbers, and common symbols.");
+        return;
+      }
       var message = update.getMessage();
 
       switch (message.getText()) {
-        case "/start":
-          sendStartMenu(chatId);
-          break;
-        case "/help":
-          sendHelpMessage(chatId);
-          break;
-        case "/prayertimes":
-          sendPrayerTimes(chatId);
-          break;
-        default:
-          sendDefaultMessage(chatId);
-          break;
+        case "/start" -> sendStartMenu(chatId);
+        case "/help" -> sendHelpMessage(chatId);
+        case "/prayertimes" -> sendPrayerTimes(chatId);
+        default -> sendDefaultMessage(chatId, message.getText());
       }
     }
 
     if (update.hasMessage() && update.getMessage().hasLocation()) {
-      var eventMessage =
-          String.format(
-              "Location request. UserId: %s, Latitude: %s, Longitude: %s",
-              chatId,
-              update.getMessage().getLocation().getLatitude(),
-              update.getMessage().getLocation().getLongitude());
-      log.info(eventMessage);
-
       var user = users.findByTelegramId(chatId);
       if (Objects.isNull(user)) {
         user = new User();
@@ -129,108 +108,43 @@ public class PrayingTimesAzanBot
       user.setLongitude(longitude);
 
       users.save(user);
-
-      var event = new Event();
-      event.setUser(user);
-      event.setTimestamp(System.currentTimeMillis());
-      event.setDescription(eventMessage);
-
-      events.save(event);
+      events.newUser(chatId);
 
       sendMessage(chatId, client.getTimesByCoordinates(latitude, longitude, 14).toString());
     }
   }
 
-  private boolean isRateLimited(Long userId) {
-    long currentTime = System.currentTimeMillis();
-    Long lastRequestTime = userLastRequestTimes.get(userId);
-    Integer requestCount = userRequestCounts.get(userId);
-
-    if (lastRequestTime == null || (currentTime - lastRequestTime) > RATE_LIMIT_TIME_WINDOW) {
-      // Reset the counter if the time window has passed
-      userRequestCounts.put(userId, 1);
-      userLastRequestTimes.put(userId, currentTime);
-      return false;
-    } else if (requestCount < MAX_REQUESTS_PER_USER) {
-      // Increment the counter
-      userRequestCounts.put(userId, requestCount + 1);
-      return false;
-    } else {
-      // Rate limit exceeded
-      return true;
-    }
-  }
-
   private boolean isValidInput(String input) {
-    // Validate input to ensure it contains only allowed characters
     return ALPHANUMERIC_PATTERN.matcher(input).matches();
-  }
-
-  private void sendMessage(SendMessage message) {
-    try {
-      telegramClient.execute(message);
-    } catch (TelegramApiException e) {
-      // Log the error without exposing sensitive details
-      System.err.println("Failed to send message: " + e.getMessage());
-    }
   }
 
   private void sendMessage(Long chatId, String text) {
     SendMessage message = SendMessage.builder().chatId(chatId).text(text).build();
-    sendMessage(message);
+    try {
+      telegramClient.execute(message);
+    } catch (TelegramApiException e) {
+      events.error(chatId, "Failed to send message: " + e.getMessage());
+    }
   }
 
   private void sendHelpMessage(Long chatId) {
-    String text = "**Help Menu**\n\n" +
-            "Here are the available commands:\n" +
-            "/start - Show the main menu\n" +
-            "/help - Get help and instructions\n" +
-            "/prayertimes - Get prayer times for your location\n\n" +
-            "To get started, share your location and choose a calculation method.\n" +
-            "Source code: https://github.com/map7000/timeskeeper";
-    sendMessage(chatId, text);
+    events.help(chatId);
+    sendMessage(chatId, HELP_MESSAGE);
   }
 
   private void sendPrayerTimes(Long chatId) {
     String text = "🕋Please share your location to get prayer times.";
+    events.timesRequest(chatId);
     sendMessage(chatId, text);
   }
 
-  private void sendDefaultMessage(Long chatId) {
-    String text = "Sorry, I didn't understand that command. 😕\n" +
-            "Use /help to see available commands.";
-    sendMessage(chatId, text);
+  private void sendDefaultMessage(Long chatId, String description) {
+    events.unknownCommand(chatId, description);
+    sendMessage(chatId, DEFAULT_MESSAGE);
   }
 
   private void sendStartMenu(Long chatId) {
-    SendMessage message = SendMessage.builder()
-            .chatId(chatId)
-            .text("Welcome to the Prayer Time Bot! 🕌\n\n" +
-                    "Use the commands below to interact with the bot:\n" +
-                    "/start - Show this menu\n" +
-                    "/help - Get help and instructions\n" +
-                    "/prayertimes - Get prayer times for your location").build();
-
-    // Create a custom keyboard
-    List<KeyboardRow> keyboard = new ArrayList<>();
-
-    // Row 1
-    KeyboardRow row1 = new KeyboardRow();
-    row1.add("/start");
-    row1.add("/help");
-
-    // Row 2
-    KeyboardRow row2 = new KeyboardRow();
-    row2.add("/prayertimes");
-
-    keyboard.add(row1);
-    keyboard.add(row2);
-
-    ReplyKeyboardMarkup keyboardMarkup = new ReplyKeyboardMarkup(keyboard);
-    keyboardMarkup.setResizeKeyboard(true); // Adjust keyboard size to fit buttons
-
-    message.setReplyMarkup(keyboardMarkup);
-    sendMessage(message);
+    events.start(chatId);
+    sendMessage(chatId, MENU_MESSAGE);
   }
-
 }

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/PrayingTimesAzanBot.java
@@ -4,7 +4,11 @@
  */
 package ru.mfilatov.prayingtimes.telegrambot;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +19,8 @@ import org.telegram.telegrambots.longpolling.starter.SpringLongPollingBot;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 import ru.mfilatov.prayingtimes.telegrambot.clients.TimeskeeperClient;
@@ -33,7 +39,14 @@ public class PrayingTimesAzanBot
   private final EventRepository events;
   private final UserRepository users;
   private final String botToken;
-  private final String DEFAULT_TEXT = "Source code: https://github.com/map7000/timeskeeper";
+
+  private static final Pattern ALPHANUMERIC_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s.,!?-]+$");
+  private static final int MAX_REQUESTS_PER_USER = 10; // Max requests per user per minute
+  private static final long RATE_LIMIT_TIME_WINDOW = 60_000; // 1 minute in milliseconds
+
+  // Simulated rate-limiting storage (in a real application, use a proper cache or database)
+  private final java.util.Map<Long, Integer> userRequestCounts = new java.util.HashMap<>();
+  private final java.util.Map<Long, Long> userLastRequestTimes = new java.util.HashMap<>();
 
   @Autowired
   public PrayingTimesAzanBot(
@@ -59,9 +72,40 @@ public class PrayingTimesAzanBot
   @Override
   public void consume(Update update) {
     Long chatId = update.getMessage().getChatId();
-    String text = DEFAULT_TEXT;
+
+    // Rate limiting check
+    if (isRateLimited(chatId)) {
+      sendMessage(chatId, "⚠️ Too many requests. Please try again later.");
+      return;
+    }
+
+    // Input validation
+    if (!isValidInput(update.getMessage().getText())) {
+      sendMessage(chatId, "⚠️ Invalid input. Please use only letters, numbers, and common symbols.");
+      return;
+    }
+
     Double latitude;
     Double longitude;
+
+    if (update.hasMessage()) {
+      var message = update.getMessage();
+
+      switch (message.getText()) {
+        case "/start":
+          sendStartMenu(chatId);
+          break;
+        case "/help":
+          sendHelpMessage(chatId);
+          break;
+        case "/prayertimes":
+          sendPrayerTimes(chatId);
+          break;
+        default:
+          sendDefaultMessage(chatId);
+          break;
+      }
+    }
 
     if (update.hasMessage() && update.getMessage().hasLocation()) {
       var eventMessage =
@@ -93,15 +137,100 @@ public class PrayingTimesAzanBot
 
       events.save(event);
 
-      text = client.getTimesByCoordinates(latitude, longitude, 14).toString();
+      sendMessage(chatId, client.getTimesByCoordinates(latitude, longitude, 14).toString());
     }
+  }
 
-    SendMessage message = SendMessage.builder().chatId(chatId).text(text).build();
+  private boolean isRateLimited(Long userId) {
+    long currentTime = System.currentTimeMillis();
+    Long lastRequestTime = userLastRequestTimes.get(userId);
+    Integer requestCount = userRequestCounts.get(userId);
 
+    if (lastRequestTime == null || (currentTime - lastRequestTime) > RATE_LIMIT_TIME_WINDOW) {
+      // Reset the counter if the time window has passed
+      userRequestCounts.put(userId, 1);
+      userLastRequestTimes.put(userId, currentTime);
+      return false;
+    } else if (requestCount < MAX_REQUESTS_PER_USER) {
+      // Increment the counter
+      userRequestCounts.put(userId, requestCount + 1);
+      return false;
+    } else {
+      // Rate limit exceeded
+      return true;
+    }
+  }
+
+  private boolean isValidInput(String input) {
+    // Validate input to ensure it contains only allowed characters
+    return ALPHANUMERIC_PATTERN.matcher(input).matches();
+  }
+
+  private void sendMessage(SendMessage message) {
     try {
       telegramClient.execute(message);
     } catch (TelegramApiException e) {
-      e.printStackTrace();
+      // Log the error without exposing sensitive details
+      System.err.println("Failed to send message: " + e.getMessage());
     }
   }
+
+  private void sendMessage(Long chatId, String text) {
+    SendMessage message = SendMessage.builder().chatId(chatId).text(text).build();
+    sendMessage(message);
+  }
+
+  private void sendHelpMessage(Long chatId) {
+    String text = "**Help Menu**\n\n" +
+            "Here are the available commands:\n" +
+            "/start - Show the main menu\n" +
+            "/help - Get help and instructions\n" +
+            "/prayertimes - Get prayer times for your location\n\n" +
+            "To get started, share your location and choose a calculation method.\n" +
+            "Source code: https://github.com/map7000/timeskeeper";
+    sendMessage(chatId, text);
+  }
+
+  private void sendPrayerTimes(Long chatId) {
+    String text = "🕋Please share your location to get prayer times.";
+    sendMessage(chatId, text);
+  }
+
+  private void sendDefaultMessage(Long chatId) {
+    String text = "Sorry, I didn't understand that command. 😕\n" +
+            "Use /help to see available commands.";
+    sendMessage(chatId, text);
+  }
+
+  private void sendStartMenu(Long chatId) {
+    SendMessage message = SendMessage.builder()
+            .chatId(chatId)
+            .text("Welcome to the Prayer Time Bot! 🕌\n\n" +
+                    "Use the commands below to interact with the bot:\n" +
+                    "/start - Show this menu\n" +
+                    "/help - Get help and instructions\n" +
+                    "/prayertimes - Get prayer times for your location").build();
+
+    // Create a custom keyboard
+    List<KeyboardRow> keyboard = new ArrayList<>();
+
+    // Row 1
+    KeyboardRow row1 = new KeyboardRow();
+    row1.add("/start");
+    row1.add("/help");
+
+    // Row 2
+    KeyboardRow row2 = new KeyboardRow();
+    row2.add("/prayertimes");
+
+    keyboard.add(row1);
+    keyboard.add(row2);
+
+    ReplyKeyboardMarkup keyboardMarkup = new ReplyKeyboardMarkup(keyboard);
+    keyboardMarkup.setResizeKeyboard(true); // Adjust keyboard size to fit buttons
+
+    message.setReplyMarkup(keyboardMarkup);
+    sendMessage(message);
+  }
+
 }

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterRepository.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterRepository.java
@@ -1,0 +1,7 @@
+package ru.mfilatov.prayingtimes.telegrambot.counter;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;
+
+public interface CounterRepository extends JpaRepository<Counter, Long> {
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterService.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterService.java
@@ -4,36 +4,44 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;
+import ru.mfilatov.prayingtimes.telegrambot.repositories.CounterRepository;
 
 @Service
 public class CounterService {
+    private final CounterRepository counterRepository;
+
     @Autowired
-    private CounterRepository counterRepository;
+    CounterService(CounterRepository counterRepository) {
+        this.counterRepository = counterRepository;
+    }
 
     @Transactional
-    public int increment() {
-        Counter counter = counterRepository.findById(1L).orElse(new Counter());
-        counter.setValue(counter.getValue() + 1);
+    public void increment(Long chatId) {
+        Counter counter = counterRepository.findById(chatId).orElse(new Counter(chatId));
+        counter.setCounterValue(counter.getCounterValue() + 1);
         counterRepository.save(counter);
-        return counter.getValue();
     }
 
     @Transactional
-    public int decrement() {
-        Counter counter = counterRepository.findById(1L).orElse(new Counter());
-        counter.setValue(counter.getValue() - 1);
+    public void decrement(Long chatId) {
+        Counter counter = counterRepository.findById(chatId).orElse(new Counter(chatId));
+        counter.setCounterValue(counter.getCounterValue() - 1);
         counterRepository.save(counter);
-        return counter.getValue();
     }
 
-    public int getCurrentValue() {
-        return counterRepository.findById(1L).orElse(new Counter()).getValue();
+    public int getCurrentValue(Long chatId) {
+        return counterRepository.findById(chatId).orElse(new Counter(chatId)).getCounterValue();
+    }
+
+    public Long getInitialTime(Long chatId) {
+        return counterRepository.findById(chatId).orElse(new Counter(chatId)).getInitialTime();
     }
 
     @Transactional
-    public void reset() {
-        Counter counter = counterRepository.findById(1L).orElse(new Counter());
-        counter.setValue(0);
+    public void reset(Long chatId) {
+        Counter counter = counterRepository.findById(chatId).orElse(new Counter(chatId));
+        counter.setCounterValue(0);
+        counter.setInitialTime(System.currentTimeMillis());
         counterRepository.save(counter);
     }
 }

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterService.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/CounterService.java
@@ -1,0 +1,39 @@
+package ru.mfilatov.prayingtimes.telegrambot.counter;
+
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;
+
+@Service
+public class CounterService {
+    @Autowired
+    private CounterRepository counterRepository;
+
+    @Transactional
+    public int increment() {
+        Counter counter = counterRepository.findById(1L).orElse(new Counter());
+        counter.setValue(counter.getValue() + 1);
+        counterRepository.save(counter);
+        return counter.getValue();
+    }
+
+    @Transactional
+    public int decrement() {
+        Counter counter = counterRepository.findById(1L).orElse(new Counter());
+        counter.setValue(counter.getValue() - 1);
+        counterRepository.save(counter);
+        return counter.getValue();
+    }
+
+    public int getCurrentValue() {
+        return counterRepository.findById(1L).orElse(new Counter()).getValue();
+    }
+
+    @Transactional
+    public void reset() {
+        Counter counter = counterRepository.findById(1L).orElse(new Counter());
+        counter.setValue(0);
+        counterRepository.save(counter);
+    }
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/RateLimiterService.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/counter/RateLimiterService.java
@@ -1,0 +1,29 @@
+package ru.mfilatov.prayingtimes.telegrambot.counter;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class RateLimiterService {
+    private static final int MAX_REQUESTS_PER_USER = 10; // Max requests per user per minute
+    private static final long RATE_LIMIT_TIME_WINDOW = 60_000; // 1 minute in milliseconds
+
+    private final CounterService counter;
+
+    public RateLimiterService(CounterService counter) {
+        this.counter = counter;
+    }
+
+    public boolean isRateLimited(Long chatId) {
+        if(counter.getCurrentValue(chatId) < MAX_REQUESTS_PER_USER) {
+            counter.increment(chatId);
+            return false;
+        }
+
+        if(System.currentTimeMillis() - counter.getInitialTime(chatId) > RATE_LIMIT_TIME_WINDOW) {
+            counter.reset(chatId);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Counter.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Counter.java
@@ -2,15 +2,25 @@ package ru.mfilatov.prayingtimes.telegrambot.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Setter
+@Getter
 @Entity
+@NoArgsConstructor
+@Table(name = "counter")
 public class Counter {
     @Id
-    private Long id = 1L; // Single row for the counter
-    @Setter
-    @Getter
-    private int value;
+    private Long chatId;
+    private Integer counterValue;
+    private Long initialTime;
 
+    public Counter(Long chatId) {
+        this.chatId = chatId;
+        counterValue = 0;
+        initialTime = System.currentTimeMillis();
+    }
 }

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Counter.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Counter.java
@@ -1,0 +1,16 @@
+package ru.mfilatov.prayingtimes.telegrambot.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+public class Counter {
+    @Id
+    private Long id = 1L; // Single row for the counter
+    @Setter
+    @Getter
+    private int value;
+
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Event.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/entities/Event.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import ru.mfilatov.prayingtimes.telegrambot.events.EventType;
 
 @Setter
 @Getter
@@ -21,11 +22,8 @@ public class Event {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-    @Version
-    private Long version;
     private Long timestamp;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="USER_ID")
-    private User user;
+    private Long chatId;
+    private EventType eventType;
     private String description;
 }

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/events/EventHandler.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/events/EventHandler.java
@@ -1,0 +1,57 @@
+package ru.mfilatov.prayingtimes.telegrambot.events;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.mfilatov.prayingtimes.telegrambot.entities.Event;
+import ru.mfilatov.prayingtimes.telegrambot.repositories.EventRepository;
+
+@Service
+public class EventHandler {
+    private final EventRepository events;
+
+    @Autowired
+    EventHandler(EventRepository events) {
+        this.events = events;
+    }
+
+    public void newUser(Long chatId) {
+        saveEvent(EventType.NEW_USER, chatId);
+    }
+
+    public void changeLocation(Long chatId) {
+        saveEvent(EventType.CHANGE_LOCATION, chatId);
+    }
+
+    public void timesRequest(Long chatId) {
+        saveEvent(EventType.TIMES_REQUEST, chatId);
+    }
+
+    public void help(Long chatId) {
+        saveEvent(EventType.HELP, chatId);
+    }
+
+    public void start(Long chatId) {
+        saveEvent(EventType.START, chatId);
+    }
+
+    public void error(Long chatId, String description ) {
+        saveEvent(EventType.ERROR, chatId, description);
+    }
+
+    public void unknownCommand(Long chatId, String description) {
+        saveEvent(EventType.UNKNOWN_COMMAND, chatId, description);
+    }
+
+    private void saveEvent(EventType eventType, Long chatId, String description) {
+        var event = new Event();
+        event.setEventType(eventType);
+        event.setChatId(chatId);
+        event.setDescription(description);
+        event.setTimestamp(System.currentTimeMillis());
+        events.save(event);
+    }
+
+    private void saveEvent(EventType eventType, Long chatId) {
+        saveEvent(eventType, chatId, "");
+    }
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/events/EventType.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/events/EventType.java
@@ -1,0 +1,11 @@
+package ru.mfilatov.prayingtimes.telegrambot.events;
+
+public enum EventType {
+    NEW_USER,
+    CHANGE_LOCATION,
+    TIMES_REQUEST,
+    HELP,
+    START,
+    ERROR,
+    UNKNOWN_COMMAND
+}

--- a/src/main/java/ru/mfilatov/prayingtimes/telegrambot/repositories/CounterRepository.java
+++ b/src/main/java/ru/mfilatov/prayingtimes/telegrambot/repositories/CounterRepository.java
@@ -1,4 +1,4 @@
-package ru.mfilatov.prayingtimes.telegrambot.counter;
+package ru.mfilatov.prayingtimes.telegrambot.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;

--- a/src/test/java/ru/mfilatov/prayingtimes/telegrambot/CounterRepositoryTest.java
+++ b/src/test/java/ru/mfilatov/prayingtimes/telegrambot/CounterRepositoryTest.java
@@ -1,0 +1,24 @@
+package ru.mfilatov.prayingtimes.telegrambot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import ru.mfilatov.prayingtimes.telegrambot.repositories.CounterRepository;
+import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;
+
+@DataJpaTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+public class CounterRepositoryTest {
+  @Autowired
+  private CounterRepository counterRepository;
+
+  @Test
+    void saveTest() {
+      counterRepository.save(new Counter(1L));
+      assertThat(counterRepository.getById(1L).getCounterValue()).isEqualTo(0);
+  }
+}

--- a/src/test/java/ru/mfilatov/prayingtimes/telegrambot/CounterServiceTest.java
+++ b/src/test/java/ru/mfilatov/prayingtimes/telegrambot/CounterServiceTest.java
@@ -1,0 +1,110 @@
+package ru.mfilatov.prayingtimes.telegrambot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import ru.mfilatov.prayingtimes.telegrambot.counter.CounterService;
+import ru.mfilatov.prayingtimes.telegrambot.entities.Counter;
+import ru.mfilatov.prayingtimes.telegrambot.repositories.CounterRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CounterServiceTest {
+
+    @Mock
+    private CounterRepository counterRepository;
+
+    @InjectMocks
+    private CounterService counterService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testIncrement() {
+        Long chatId = 123L;
+        Counter counter = new Counter(chatId);
+        counter.setCounterValue(5);
+
+        when(counterRepository.findById(chatId)).thenReturn(Optional.of(counter));
+        when(counterRepository.save(any(Counter.class))).thenReturn(counter);
+
+        counterService.increment(chatId);
+
+        assertThat(counter.getCounterValue()).isEqualTo(6);
+        verify(counterRepository, times(1)).findById(chatId);
+        verify(counterRepository, times(1)).save(counter);
+    }
+
+    @Test
+    void testDecrement() {
+        Long chatId = 123L;
+        Counter counter = new Counter(chatId);
+        counter.setCounterValue(5);
+
+        when(counterRepository.findById(chatId)).thenReturn(Optional.of(counter));
+        when(counterRepository.save(any(Counter.class))).thenReturn(counter);
+
+        counterService.decrement(chatId);
+
+        int result = counterService.getCurrentValue(chatId);
+
+        assertThat(result).isEqualTo(4);
+        verify(counterRepository, times(2)).findById(chatId);
+        verify(counterRepository, times(1)).save(counter);
+    }
+
+    @Test
+    void testGetCurrentValue() {
+        Long chatId = 123L;
+        Counter counter = new Counter(chatId);
+        counter.setCounterValue(10);
+
+        when(counterRepository.findById(chatId)).thenReturn(Optional.of(counter));
+
+        int result = counterService.getCurrentValue(chatId);
+
+        assertThat(result).isEqualTo(10);
+        verify(counterRepository, times(1)).findById(chatId);
+    }
+
+    @Test
+    void testReset() {
+        Long chatId = 123L;
+        Counter counter = new Counter(chatId);
+        counter.setCounterValue(10);
+
+        when(counterRepository.findById(chatId)).thenReturn(Optional.of(counter));
+        when(counterRepository.save(any(Counter.class))).thenReturn(counter);
+
+        counterService.reset(chatId);
+
+        assertThat(counter.getCounterValue()).isEqualTo(0);
+        verify(counterRepository, times(1)).findById(chatId);
+        verify(counterRepository, times(1)).save(counter);
+    }
+
+    @Test
+    void testIncrementWhenCounterDoesNotExist() {
+        Long chatId = 123L;
+        Counter newCounter = new Counter(chatId);
+        newCounter.setCounterValue(1);
+
+        when(counterRepository.findById(chatId)).thenReturn(Optional.empty());
+        when(counterRepository.save(any(Counter.class))).thenReturn(newCounter);
+
+        counterService.increment(chatId);
+
+        assertThat(newCounter.getCounterValue()).isEqualTo(1);
+        verify(counterRepository, times(1)).findById(chatId);
+        verify(counterRepository, times(1)).save(any(Counter.class));
+    }
+}

--- a/src/test/java/ru/mfilatov/prayingtimes/telegrambot/EventRepositoryTest.java
+++ b/src/test/java/ru/mfilatov/prayingtimes/telegrambot/EventRepositoryTest.java
@@ -21,24 +21,16 @@ import ru.mfilatov.prayingtimes.telegrambot.repositories.UserRepository;
 public class EventRepositoryTest {
 
     @Autowired
-    private UserRepository userRepository;
-    @Autowired
     private EventRepository eventRepository;
 
     @Test
     public void testSaveEvent() {
-        User user = new TestObjectFactory().createTelegramUser();
-        userRepository.save(user);
 
-        Event event = new TestObjectFactory().createEvent(user);
+        Event event = new TestObjectFactory().createEvent();
         eventRepository.save(event);
 
         var savedEvent = eventRepository.findById(event.getId()).orElse(null);
         assertThat(savedEvent).as("Can find event by id").isNotNull();
         assertThat(savedEvent).as("Event data saved correctly").isEqualTo(event);
-
-        var savedUser = savedEvent.getUser();
-        assertThat(savedUser).as("Can find user by event").isNotNull();
-        assertThat(savedUser).as("User data saved correctly").isEqualTo(user);
     }
 }

--- a/src/test/java/ru/mfilatov/prayingtimes/telegrambot/RateLimiterServiceTest.java
+++ b/src/test/java/ru/mfilatov/prayingtimes/telegrambot/RateLimiterServiceTest.java
@@ -1,0 +1,82 @@
+package ru.mfilatov.prayingtimes.telegrambot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import ru.mfilatov.prayingtimes.telegrambot.counter.CounterService;
+import ru.mfilatov.prayingtimes.telegrambot.counter.RateLimiterService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class RateLimiterServiceTest {
+
+    @Mock
+    private CounterService counterService;
+
+    @InjectMocks
+    private RateLimiterService rateLimiterService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testIsRateLimited_WhenBelowLimit_ShouldReturnFalseAndIncrementCounter() {
+        Long chatId = 123L;
+        when(counterService.getCurrentValue(chatId)).thenReturn(5);
+        when(counterService.getInitialTime(chatId)).thenReturn(System.currentTimeMillis());
+
+        boolean result = rateLimiterService.isRateLimited(chatId);
+
+        assertThat(result).isFalse();
+        verify(counterService, times(1)).getCurrentValue(chatId);
+        verify(counterService, times(1)).increment(chatId);
+        verify(counterService, never()).reset(chatId);
+    }
+
+    @Test
+    void testIsRateLimited_WhenAtLimitButTimeWindowExpired_ShouldReturnFalseAndResetCounter() {
+        Long chatId = 123L;
+        when(counterService.getCurrentValue(chatId)).thenReturn(10);
+        when(counterService.getInitialTime(chatId)).thenReturn(System.currentTimeMillis() - 61_000);
+
+        boolean result = rateLimiterService.isRateLimited(chatId);
+
+        assertThat(result).isFalse();
+        verify(counterService, times(1)).getCurrentValue(chatId);
+        verify(counterService, times(1)).reset(chatId);
+        verify(counterService, never()).increment(chatId);
+    }
+
+    @Test
+    void testIsRateLimited_WhenAtLimitAndTimeWindowNotExpired_ShouldReturnTrue() {
+        Long chatId = 123L;
+        when(counterService.getCurrentValue(chatId)).thenReturn(10);
+        when(counterService.getInitialTime(chatId)).thenReturn(System.currentTimeMillis() - 30_000);
+
+        boolean result = rateLimiterService.isRateLimited(chatId);
+
+        assertThat(result).isTrue(); // Rate-limited
+        verify(counterService, times(1)).getCurrentValue(chatId);
+        verify(counterService, never()).reset(chatId);
+        verify(counterService, never()).increment(chatId);
+    }
+
+    @Test
+    void testIsRateLimited_WhenCounterDoesNotExist_ShouldReturnFalseAndIncrementCounter() {
+        Long chatId = 123L;
+        when(counterService.getCurrentValue(chatId)).thenReturn(0);
+        when(counterService.getInitialTime(chatId)).thenReturn(System.currentTimeMillis());
+
+        boolean result = rateLimiterService.isRateLimited(chatId);
+
+        assertThat(result).isFalse();
+        verify(counterService, times(1)).getCurrentValue(chatId);
+        verify(counterService, times(1)).increment(chatId);
+        verify(counterService, never()).reset(chatId);
+    }
+}

--- a/src/test/java/ru/mfilatov/prayingtimes/telegrambot/TestObjectFactory.java
+++ b/src/test/java/ru/mfilatov/prayingtimes/telegrambot/TestObjectFactory.java
@@ -7,6 +7,7 @@ package ru.mfilatov.prayingtimes.telegrambot;
 import org.apache.commons.lang3.RandomUtils;
 import ru.mfilatov.prayingtimes.telegrambot.entities.Event;
 import ru.mfilatov.prayingtimes.telegrambot.entities.User;
+import ru.mfilatov.prayingtimes.telegrambot.events.EventType;
 
 public class TestObjectFactory {
     public User createTelegramUser() {
@@ -17,9 +18,10 @@ public class TestObjectFactory {
         return user;
     }
 
-    public Event createEvent(User user) {
+    public Event createEvent() {
         var event = new Event();
-        event.setUser(user);
+        event.setEventType(EventType.START);
+        event.setChatId(1L);
         event.setTimestamp(System.currentTimeMillis());
         event.setDescription("Test event");
         return event;


### PR DESCRIPTION
This pull request introduces a Rate Limiter Service to enforce rate limits on user requests. The service ensures that users cannot exceed a predefined number of requests within a specific time window (e.g., 10 requests per minute). This is particularly useful for preventing abuse, ensuring fair usage, and protecting the system from being overwhelmed by excessive requests.